### PR TITLE
Add Flask backoffice UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,17 @@
 # codex-test
+
+This repository contains a minimal backoffice UI implemented in Python using Flask and SQLAlchemy. It demonstrates a small CRUD interface for managing products.
+
+## Requirements
+
+- Python 3.11+
+- The packages listed in `requirements.txt`
+
+## Running the application
+
+1. (Optional) Create a virtual environment and activate it.
+2. Install dependencies with `pip install -r requirements.txt`.
+3. Run the application using `python main.py`.
+4. Open `http://localhost:5000/` in your browser to access the backoffice.
+
+The UI uses Bootstrap for basic styling via CDN.

--- a/forms.py
+++ b/forms.py
@@ -1,0 +1,8 @@
+from flask_wtf import FlaskForm
+from wtforms import StringField, DecimalField, SubmitField
+from wtforms.validators import DataRequired
+
+class ProductForm(FlaskForm):
+    name = StringField('Name', validators=[DataRequired()])
+    price = DecimalField('Price', validators=[DataRequired()])
+    submit = SubmitField('Save')

--- a/main.py
+++ b/main.py
@@ -1,0 +1,51 @@
+from flask import Flask, render_template, redirect, url_for, flash
+from forms import ProductForm
+from models import db, Product, init_app
+
+
+def create_app():
+    app = Flask(__name__)
+    app.config['SQLALCHEMY_DATABASE_URI'] = 'sqlite:///backoffice.db'
+    app.config['SECRET_KEY'] = 'change-me'
+    init_app(app)
+
+    @app.route('/')
+    def product_list():
+        products = Product.query.all()
+        return render_template('product_list.html', products=products)
+
+    @app.route('/product/new', methods=['GET', 'POST'])
+    def create_product():
+        form = ProductForm()
+        if form.validate_on_submit():
+            product = Product(name=form.name.data, price=float(form.price.data))
+            db.session.add(product)
+            db.session.commit()
+            flash('Product created')
+            return redirect(url_for('product_list'))
+        return render_template('product_form.html', form=form)
+
+    @app.route('/product/<int:product_id>/edit', methods=['GET', 'POST'])
+    def edit_product(product_id):
+        product = Product.query.get_or_404(product_id)
+        form = ProductForm(obj=product)
+        if form.validate_on_submit():
+            form.populate_obj(product)
+            db.session.commit()
+            flash('Product updated')
+            return redirect(url_for('product_list'))
+        return render_template('product_form.html', form=form)
+
+    @app.route('/product/<int:product_id>/delete')
+    def delete_product(product_id):
+        product = Product.query.get_or_404(product_id)
+        db.session.delete(product)
+        db.session.commit()
+        flash('Product deleted')
+        return redirect(url_for('product_list'))
+
+    return app
+
+if __name__ == '__main__':
+    app = create_app()
+    app.run(debug=True)

--- a/models.py
+++ b/models.py
@@ -1,0 +1,13 @@
+from flask_sqlalchemy import SQLAlchemy
+
+db = SQLAlchemy()
+
+class Product(db.Model):
+    id = db.Column(db.Integer, primary_key=True)
+    name = db.Column(db.String(120), nullable=False)
+    price = db.Column(db.Float, nullable=False)
+
+def init_app(app):
+    db.init_app(app)
+    with app.app_context():
+        db.create_all()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+Flask>=2.3
+Flask-SQLAlchemy>=3.0
+Flask-WTF>=1.1
+

--- a/templates/base.html
+++ b/templates/base.html
@@ -1,0 +1,25 @@
+<!doctype html>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+    <title>{% block title %}Backoffice{% endblock %}</title>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css">
+</head>
+<body>
+<nav class="navbar navbar-expand-lg navbar-light bg-light mb-4">
+    <div class="container-fluid">
+        <a class="navbar-brand" href="/">Backoffice</a>
+    </div>
+</nav>
+<div class="container">
+    {% with messages = get_flashed_messages() %}
+      {% if messages %}
+        <div class="alert alert-info">
+          {{ messages[0] }}
+        </div>
+      {% endif %}
+    {% endwith %}
+    {% block content %}{% endblock %}
+</div>
+</body>
+</html>

--- a/templates/product_form.html
+++ b/templates/product_form.html
@@ -1,0 +1,23 @@
+{% extends 'base.html' %}
+{% if form.name.data %}
+  {% set title = 'Edit Product' %}
+{% else %}
+  {% set title = 'New Product' %}
+{% endif %}
+{% block title %}{{ title }}{% endblock %}
+{% block content %}
+<h1>{{ title }}</h1>
+<form method="post">
+    {{ form.hidden_tag() }}
+    <div class="mb-3">
+        {{ form.name.label(class="form-label") }}
+        {{ form.name(class="form-control") }}
+    </div>
+    <div class="mb-3">
+        {{ form.price.label(class="form-label") }}
+        {{ form.price(class="form-control") }}
+    </div>
+    {{ form.submit(class="btn btn-primary") }}
+    <a class="btn btn-secondary" href="{{ url_for('product_list') }}">Cancel</a>
+</form>
+{% endblock %}

--- a/templates/product_list.html
+++ b/templates/product_list.html
@@ -1,0 +1,26 @@
+{% extends 'base.html' %}
+{% block title %}Products{% endblock %}
+{% block content %}
+<div class="d-flex justify-content-between align-items-center mb-3">
+    <h1>Products</h1>
+    <a class="btn btn-primary" href="{{ url_for('create_product') }}">New Product</a>
+</div>
+<table class="table table-striped">
+<thead>
+<tr><th>ID</th><th>Name</th><th>Price</th><th>Actions</th></tr>
+</thead>
+<tbody>
+{% for product in products %}
+<tr>
+<td>{{ product.id }}</td>
+<td>{{ product.name }}</td>
+<td>{{ "%.2f"|format(product.price) }}</td>
+<td>
+    <a class="btn btn-sm btn-secondary" href="{{ url_for('edit_product', product_id=product.id) }}">Edit</a>
+    <a class="btn btn-sm btn-danger" href="{{ url_for('delete_product', product_id=product.id) }}">Delete</a>
+</td>
+</tr>
+{% endfor %}
+</tbody>
+</table>
+{% endblock %}


### PR DESCRIPTION
## Summary
- add simple Flask app for CRUD management of products
- include SQLAlchemy models and WTForms forms
- provide Bootstrap-based templates
- update documentation with setup instructions

## Testing
- `python3 -m py_compile main.py models.py forms.py`
- `pytest -q` *(fails: command not found)*